### PR TITLE
Update SRI integrity hashes for all third-party JS files

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -3,8 +3,8 @@
   <head>
     <meta charset="UTF-8" http-equiv="X-UA-Compatible" content="IE=edge">
     <title data-i18n="app.title">Signum Classic Wallet</title>
-    <script src="js/3rdparty/jquery.min.js"     integrity="sha384-tsQFqpEReu7ZLhBV2VZlAu7zcOV+rXbYlF2cqB8txI/8aZajjp4Bqd+V6D5IgvKT" type="text/javascript"></script>
-    <script src="js/3rdparty/bootstrap.min.js"  integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" type="text/javascript"></script>
+    <script src="js/3rdparty/jquery.min.js"     integrity="sha384-Q4GEli30r5Awgb/ITt925nE8buHKjVWM/x3DX8t5JwRLT9P/C2r7u7XzNwvpTTGw" type="text/javascript"></script>
+    <script src="js/3rdparty/bootstrap.min.js"  integrity="sha384-11BkEKkLaZodUOvC3u6XmVZPUGl9CdsP3FgdD0jcPCO+2DWjzeZxvrwvelKOq+NX" type="text/javascript"></script>
 <!--ui css -->
     <link href="css/dev/burstold.css" rel="stylesheet" type="text/css" />
 
@@ -52,7 +52,7 @@
     <!-- Pages moved to own files in html/pages/ -->
 
     <!-- Modals moved to own files in html/modals/ -->
-    <script src="js/3rdparty/i18next.min.js"    integrity="sha384-X4jdmLV1bQZERlyBmLg6XKIekmkGCaCl4GnEMPFPZ7v8wy8MRQX8XdDFSlnwDf1p" type="text/javascript"></script>
+    <script src="js/3rdparty/i18next.min.js"    integrity="sha384-URFXwCz7DKc4HBbsHYcD3LW3CAhtIwQci5ijmuUhjcFXsosTJLJkFLN2TG84opwV" type="text/javascript"></script>
     <script type="text/javascript">
       $.i18n.init({
         fallbackLng: "en",
@@ -66,18 +66,18 @@
       });
       $("#loading_bar" ).val (25);
     </script>
-    <script src="js/3rdparty/ajaxmultiqueue.js" integrity="sha384-z4oBihrMyAEYUPZWuSscFRjhJsg8Xh5BjNf6W5eq34YtZ9yFeGLXABTJR7VabVTG" type="text/javascript"></script>
-    <script src="js/3rdparty/ajaxretry.js"      integrity="sha384-ia90j7KZ3lHwnJ/jSofQNFuwwtGrcTHwjd9+SY8Ls7EFiyx+vFfXvURO9fW0odQj" type="text/javascript"></script>
-    <script src="js/3rdparty/big.min.js"        integrity="sha384-BWcgDmoCXi+1663OmG90jk7M9rKeNHdZNVGSkq7LStLwsG62LF3MwBzzR4PhecM0" type="text/javascript"></script>
+    <script src="js/3rdparty/ajaxmultiqueue.js" integrity="sha384-nkyX9IYsrMS+O9GX9kdK6YHcMoeXO9zGqpy8oVr8XKQkQ4Lub9vtcHF1X5nVKxX2" type="text/javascript"></script>
+    <script src="js/3rdparty/ajaxretry.js"      integrity="sha384-weIQGnRJujH6EpJmXxschvptFKZgbpnMzApts42XWk7dN2G1PkNFBGqpqvFKzlQn" type="text/javascript"></script>
+    <script src="js/3rdparty/big.min.js"        integrity="sha384-SqOIZYutH685eYfGuRLcTLhwoReZlpDu7T+XhH9LaXzd7Waf7DMWq8EJwYAQWsjL" type="text/javascript"></script>
     <script src="js/3rdparty/bignumber.min.js" type="text/javascript"></script>
     <script src="js/3rdparty/adminlte.js" type="text/javascript"></script>
     <script src="js/3rdparty/clipboard.js" type="text/javascript"></script>
     <script src="js/3rdparty/jquery.rss.min.js" type="text/javascript"></script>
     <script src="js/3rdparty/webdb.js" type="text/javascript"></script>
-    <script src="js/3rdparty/notify.min.js"      integrity="sha384-Qnyy4lkYCL9J8NhIWAT7bMPccirUwfiBj7PLqr1ZBlSSJ0+A2XDB0UlqZcg+0VGS" type="text/javascript"></script>
+    <script src="js/3rdparty/notify.min.js"      integrity="sha384-/lF+AAROZ2t0F+vtaJ2TsGf/iBpukouvVDfOKRdXpQ+bc8sib5+tEVa9Y7f5KgBg" type="text/javascript"></script>
     <script src="js/3rdparty/jsbn.js" type="text/javascript"></script>
     <script src="js/3rdparty/jsbn2.js" type="text/javascript"></script>
-    <script src="js/3rdparty/pako.min.js" integrity="sha384-/Dozgal5hQaXErIqQTlUHkj+FNDLXHv4HISt/dfkCS5UrANMOYie1urQogG0QhxC" type="text/javascript"></script>
+    <script src="js/3rdparty/pako.min.js" integrity="sha384-wxYDxtnf5oqoq9i+8SrWjU74RamaqDijACyI5+D4awBHyAXDtFl5HetJCH2SK+nC" type="text/javascript"></script>
     <script src="js/3rdparty/qrcode.js" type="text/javascript"></script>
     <script>
         $("#loading_bar" ).val (30);
@@ -141,3 +141,4 @@
     <script src="js/nsv.dividends.js" type="text/javascript"></script>
   </body>
 </html>
+


### PR DESCRIPTION
### 🔧 What has changed

This PR updates the `integrity` attributes (Subresource Integrity - SRI) for all third-party JavaScript files referenced in `index.html` of the Signum Classic Wallet.

### 📚 Why this change was necessary

The `integrity` hashes were outdated and no longer matched the actual file contents of several third-party libraries (e.g., `jquery.min.js`, `bootstrap.min.js`, etc.). This caused modern browsers to block the scripts from loading due to SRI mismatch errors.

This issue surfaced especially after recent deployments and/or local testing, even though the wallet source code itself has not changed. The cause: updated or replaced `.js` files (intentionally or via build/replacement) without updating the corresponding integrity hashes.

### ✅ What this PR does

- Recalculates the correct SHA-384 hashes for all third-party JS files in `/classic/js/3rdparty/`
- Updates the `integrity="sha384-..."` attributes in `index.html` accordingly

### 🔐 Benefit

Subresource Integrity (SRI) ensures that loaded resources have not been tampered with. Updating the hashes restores full security validation and eliminates browser-side loading errors.

### 📦 Affected files

- `index.html`

### 🧪 Tested

✅ Verified in modern browsers (Chrome, Firefox)  
✅ Scripts load successfully with no SRI errors
✅ Check the new code here : https://europe2.signum.network/classic/index2.html 

---

Let me know if you'd like this change backported to other branches.
